### PR TITLE
Feature: Rollback n migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ turtle down
 ```
 
 ### TODO
-- Ability to revert _n_ migrations
 - Ability to revert to migration _x_
 - Add PostgreSQL support
 - Provide information output on performed migrations

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -132,6 +132,73 @@ var _ = Describe("migration", func() {
 
 	})
 
+	Describe(".Rollback(n)", func() {
+		Context("when n is 0", func() {
+			It("doesn't rollback any migrations", func() {
+				expectMigrationsTablePresenceQuery()
+
+				err := Rollback(0)
+
+				Expect(err).NotTo(HaveOccurred())
+
+			})
+		})
+
+		Context("when n is 1", func() {
+			It("rolls back a single migration", func() {
+				expectMigrationsTablePresenceQuery()
+
+				expectedMigrationActiveQuery("20150703234300003_third", true)
+				expectedMigration("DROP TABLE third")
+				expectedMigrationLogDelete("20150703234300003_third")
+
+				err := Rollback(1)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when n is 2", func() {
+			It("rolls back two migrations", func() {
+				expectMigrationsTablePresenceQuery()
+
+				expectedMigrationActiveQuery("20150703234300003_third", true)
+				expectedMigration("DROP TABLE third")
+				expectedMigrationLogDelete("20150703234300003_third")
+
+				expectedMigrationActiveQuery("20150703234300002_second", true)
+				expectedMigration("DROP TABLE second")
+				expectedMigrationLogDelete("20150703234300002_second")
+
+				err := Rollback(2)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when n is greater than the applied migrations", func() {
+			It("rolls back all migrations", func() {
+				expectMigrationsTablePresenceQuery()
+
+				expectedMigrationActiveQuery("20150703234300003_third", true)
+				expectedMigration("DROP TABLE third")
+				expectedMigrationLogDelete("20150703234300003_third")
+
+				expectedMigrationActiveQuery("20150703234300002_second", true)
+				expectedMigration("DROP TABLE second")
+				expectedMigrationLogDelete("20150703234300002_second")
+
+				expectedMigrationActiveQuery("20150703234300001_first", true)
+				expectedMigration("DROP TABLE first")
+				expectedMigrationLogDelete("20150703234300001_first")
+
+				err := Rollback(4)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
 	Describe(".RevertAll", func() {
 		Context("with all active migrations", func() {
 			It("reverts all migrations", func() {

--- a/migrator.go
+++ b/migrator.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"strconv"
 
 	"github.com/codegangsta/cli"
 	"github.com/nicday/turtle/migration"
@@ -28,7 +30,6 @@ func main() {
 					migrationName := c.Args()[0]
 					migration.Generate(migrationName)
 				}
-
 			},
 		},
 		cli.Command{
@@ -36,7 +37,6 @@ func main() {
 			Aliases: []string{"u"},
 			Usage:   "Processes all outstanding migrations",
 			Action: func(c *cli.Context) {
-				// db.CreateMigrationsTable()
 				migration.ApplyAll()
 			},
 		},
@@ -46,6 +46,24 @@ func main() {
 			Usage:   "Processes all outstanding migrations",
 			Action: func(c *cli.Context) {
 				migration.RevertAll()
+			},
+		},
+		cli.Command{
+			Name:    "rollback",
+			Aliases: []string{"r"},
+			Usage:   "Rollback n active migrations",
+			Action: func(c *cli.Context) {
+				if len(c.Args()) == 0 {
+					fmt.Println("Please call with a number of migrations to rollback, e.g. `turtle rollback 3`")
+					return
+				}
+				if len(c.Args()) != 0 {
+					n, err := strconv.Atoi(c.Args()[0])
+					if err != nil {
+						log.Fatal("[Error] Rollback parameter is not an integer")
+					}
+					migration.Rollback(n)
+				}
 			},
 		},
 	}


### PR DESCRIPTION
Allows for the user to specify how many migrations to roll back using `turtle rollback [n]`
